### PR TITLE
Feature/phase 04

### DIFF
--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/Extensions/ServiceCollectionExtensions.cs
@@ -290,8 +290,11 @@ namespace TC.CloudGames.Users.Api.Extensions
                 // -------------------------------
 
                 opts.UseSystemTextJsonForSerialization();
+                opts.ApplicationAssembly = typeof(Program).Assembly;
+
                 const string wolverineSchema = "wolverine";
                 opts.Durability.MessageStorageSchemaName = wolverineSchema;
+                opts.ServiceName = "tccloudgames";
 
                 // -------------------------------
                 // Persist Wolverine messages in Postgres using the same schema

--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/appsettings.json
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/appsettings.json
@@ -4,6 +4,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Debug",
+      "Wolverine": "Debug",
       "System.Net.Http.HttpClient": "Trace"
     }
   },


### PR DESCRIPTION
This pull request introduces configuration improvements for Wolverine messaging in the `TC.CloudGames.Users.Api` adapter. The changes focus on better logging and more explicit service identification for Wolverine, which should help with diagnostics and message handling.

**Wolverine Messaging Configuration:**

* Set the `ApplicationAssembly` property to `typeof(Program).Assembly` for Wolverine, ensuring it uses the correct assembly context.
* Set the `ServiceName` property for Wolverine to `"tccloudgames"`, making service identification more explicit.

**Logging Enhancements:**

* Added a specific log level for `Wolverine` set to `Debug` in `appsettings.json` for improved visibility into messaging operations.