### PR TITLE
Normalize PathBase for ingress path prefix support

### DIFF
--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/Program.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/Program.cs
@@ -23,6 +23,7 @@ var logger = app.Services.GetRequiredService<ILogger<TC.CloudGames.Users.Api.Pro
 TelemetryConstants.LogTelemetryConfiguration(logger, app.Configuration);
 
 // Use metrics authentication middleware extension
+app.UseIngressPathBase(app.Configuration);
 app.UseMetricsAuthentication();
 
 app.UseAuthentication()


### PR DESCRIPTION
Added UseIngressPathBase extension to handle path normalization when running behind an ingress or reverse proxy with a path prefix. This method applies configured base paths and processes the X-Forwarded-Prefix header to ensure correct routing. Integrated the middleware early in the pipeline in Program.cs for proper request handling.