### PR TITLE
Refactor Swagger/OpenAPI config for custom PathBase

### DIFF
--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/Extensions/ApplicationBuilderExtensions.cs
@@ -88,19 +88,29 @@ namespace TC.CloudGames.Users.Api.Extensions
 
                     return problemDetails;
                 };
-            })
-            .UseSwaggerGen(uiConfig: ui =>
-            {
-                var pathBase = Environment.GetEnvironmentVariable("ASPNETCORE_APPL_PATH")
-                    ?? configuration["ASPNETCORE_APPL_PATH"]
-                    ?? configuration["PathBase"]
-                    ?? string.Empty;
+            });
 
+            // Get PathBase for server URL modification
+            var pathBase = Environment.GetEnvironmentVariable("ASPNETCORE_APPL_PATH")
+                ?? configuration["ASPNETCORE_APPL_PATH"]
+                ?? configuration["PathBase"]
+                ?? string.Empty;
+
+            // Enable OpenAPI with server modification
+            app.UseOpenApi(o =>
+            {
                 if (!string.IsNullOrWhiteSpace(pathBase))
                 {
-                    ui.ServerUrl = pathBase;
+                    o.PostProcess = (doc, req) =>
+                    {
+                        doc.Servers.Clear();
+                        doc.Servers.Add(new NSwag.OpenApiServer { Url = pathBase });
+                    };
                 }
             });
+
+            // Enable Swagger UI
+            app.UseSwaggerUi(c => c.ConfigureDefaults());
 
             return app;
         }


### PR DESCRIPTION
Replaces .UseSwaggerGen with .UseOpenApi and .UseSwaggerUi, moving PathBase retrieval outside the Swagger config. Sets the OpenAPI server URL via PostProcess when PathBase is defined, ensuring accurate server URLs in the generated spec. Separates OpenAPI document generation from UI configuration for improved clarity and maintainability.