### PR TITLE
fix(swagger): normalize pathBase to ensure leading slash

### DIFF
--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/Extensions/ApplicationBuilderExtensions.cs
@@ -154,9 +154,19 @@ namespace TC.CloudGames.Users.Api.Extensions
                 
                 // Use absolute path WITH the PathBase prefix
                 // This ensures the URL is correct regardless of nginx rewriting
-                var swaggerJsonPath = string.IsNullOrEmpty(pathBase) 
-                    ? "/swagger/v1/swagger.json"
-                    : $"{pathBase.TrimEnd('/')}/swagger/v1/swagger.json";
+                // Normalize pathBase to ensure it starts with '/' (handles "user" vs "/user")
+                string swaggerJsonPath;
+                if (string.IsNullOrEmpty(pathBase))
+                {
+                    swaggerJsonPath = "/swagger/v1/swagger.json";
+                }
+                else
+                {
+                    var normalizedPathBase = pathBase.StartsWith('/') 
+                        ? pathBase.TrimEnd('/') 
+                        : $"/{pathBase.TrimEnd('/')}";
+                    swaggerJsonPath = $"{normalizedPathBase}/swagger/v1/swagger.json";
+                }
                 
                 c.SwaggerRoutes.Add(new SwaggerUiRoute("v1", swaggerJsonPath));
                 


### PR DESCRIPTION
Addresses Copilot Code Review suggestion: pathBase string manipulation should ensure it starts with a leading slash to prevent malformed URLs.

If ASPNETCORE_APPL_PATH is set to 'user' instead of '/user', the resulting path would be 'user/swagger/v1/swagger.json' instead of '/user/swagger/v1/swagger.json'.

Now normalizes pathBase before concatenation.