### PR TITLE
Switch APM to Azure Monitor; update Wolverine & OTEL config

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition="'$(MSBuildProjectExtension)' != '.dcproj'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.16.1.129956">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.17.0.131074">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/AssemblyInfo.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/AssemblyInfo.cs
@@ -19,7 +19,6 @@ global using Serilog;
 global using Serilog.Core;
 global using Serilog.Enrichers.Span;
 global using Serilog.Events;
-global using Serilog.Sinks.Grafana.Loki;
 global using System.Diagnostics.CodeAnalysis;
 global using System.Net;
 global using TC.CloudGames.Contracts.Events.Users;

--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/TC.CloudGames.Users.Api.csproj
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/TC.CloudGames.Users.Api.csproj
@@ -16,7 +16,6 @@
 		<PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
 		<PackageReference Include="Serilog.Enrichers.Sensitive" Version="2.1.0" />
 		<PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />
-		<PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="8.3.1" />
 
 		<!-- Misc -->
 		<PackageReference Include="DotNetEnv" Version="3.1.1" />
@@ -27,16 +26,16 @@
 		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
 
 		<!-- Wolverine - ES / MessageBroker / Outbox -->
-		<PackageReference Include="Weasel.Core" Version="8.4.1" />
+		<PackageReference Include="Weasel.Core" Version="8.4.2" />
 		<PackageReference Include="Marten" Version="8.17.0" />
-		<PackageReference Include="WolverineFx" Version="5.8.0" />
-		<PackageReference Include="WolverineFx.AzureServiceBus" Version="5.8.0" />
-		<PackageReference Include="WolverineFx.Marten" Version="5.8.0" />
-		<PackageReference Include="WolverineFx.RabbitMQ" Version="5.8.0" />
+		<PackageReference Include="WolverineFx" Version="5.9.2" />
+		<PackageReference Include="WolverineFx.AzureServiceBus" Version="5.9.2" />
+		<PackageReference Include="WolverineFx.Marten" Version="5.9.2" />
+		<PackageReference Include="WolverineFx.RabbitMQ" Version="5.9.2" />
 
-		<!-- OpenTelemetry Core Packages -->
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
+		<!-- Azure Monitor OpenTelemetry (APM for Production) -->
+		<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
+		<PackageReference Include="Azure.Identity" Version="1.17.1" />
 
 		<!-- OpenTelemetry Instrumentation Packages -->
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
@@ -49,6 +48,10 @@
 
 		<!-- OpenTelemetry Prometheus Exporter -->
 		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.14.0-beta.1" />
+
+		<!-- OpenTelemetry OTLP Exporter (Optional - for Grafana Agent fallback) -->
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
 
 		<!-- FusionCache OpenTelemetry Support -->
 		<PackageReference Include="ZiggyCreatures.FusionCache.OpenTelemetry" Version="2.4.0" />

--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/appsettings.Production.json
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/appsettings.Production.json
@@ -5,6 +5,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "AzureMonitor": {
+    "_comment": "Azure Monitor / Application Insights configuration. SamplingRatio: 1.0 = 100%, 0.5 = 50%, 0.1 = 10%",
+    "SamplingRatio": 1.0
+  },
   "MessageBroker": {
     "Type": "AzureServiceBus"
   },


### PR DESCRIPTION
This pull request introduces significant improvements to telemetry and monitoring for the `TC.CloudGames.Users.Api` service. The main change is the addition of Azure Monitor / Application Insights integration for production environments, with a fallback to Grafana Agent OTLP exporter for local development. It also updates several dependencies, removes unused packages, and expands OpenTelemetry instrumentation sources for better observability.

**Telemetry and Monitoring Enhancements:**

* Added Azure Monitor / Application Insights exporter integration for production telemetry, using `Azure.Monitor.OpenTelemetry.AspNetCore` and `Azure.Identity` for RBAC/Workload Identity authentication. Configuration is prioritized to use Azure Monitor when available, with sampling ratio and live metrics support. [[1]](diffhunk://#diff-e33cbad8359ceac5c97f95b0fec1b339cb01c7ad4727e014090ecc646fea0924L1-R3) [[2]](diffhunk://#diff-e33cbad8359ceac5c97f95b0fec1b339cb01c7ad4727e014090ecc646fea0924R42-R109) [[3]](diffhunk://#diff-f87591fe857275f31fe37174b20e078d4113e9a3d9979761e35eacd036e19506R8-R11)
* Improved fallback logic to use Grafana Agent OTLP exporter for local development, and provided clear console warnings when no telemetry exporter is configured.
* Expanded OpenTelemetry sources to include Wolverine and Marten for more comprehensive distributed tracing.

**Dependency Updates and Cleanup:**

* Updated `SonarAnalyzer.CSharp` to version 10.17.0 and upgraded Wolverine/Marten/Weasel dependencies to latest versions for bug fixes and new features. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL15-R15) [[2]](diffhunk://#diff-eedea25a18b65d850b4d849ecef6ed62fb848b2f46dd601143d95c3f6e09f680L30-R38)
* Removed unused `Serilog.Sinks.Grafana.Loki` package and related global using, as logging is no longer exported to Grafana Loki. [[1]](diffhunk://#diff-eedea25a18b65d850b4d849ecef6ed62fb848b2f46dd601143d95c3f6e09f680L19) [[2]](diffhunk://#diff-0467f89a4115f2c588d6561c71f1b446d35e613313aafe3f37d0086f02dc42c9L22)

**Configuration Improvements:**

* Added `AzureMonitor` section to `appsettings.Production.json` for configuring sampling ratio and documenting telemetry options.- Replace Grafana Loki with Azure Monitor Application Insights for production telemetry
- Add Azure.Monitor.OpenTelemetry.AspNetCore and Azure.Identity; support RBAC/Workload Identity via DefaultAzureCredential
- Enable configurable sampling ratio and Live Metrics for Azure Monitor
- Make Grafana Agent OTLP exporter a fallback for local development
- Add Wolverine and Marten as OpenTelemetry sources
- Update SonarAnalyzer.CSharp, Weasel.Core, and WolverineFx packages
- Move OTLP exporter packages to optional; only used for Grafana fallback
- Add AzureMonitor config section to appsettings.Production.json