### PR TITLE
Improve AzureMonitor sampling ratio config validation

### DIFF
--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/Extensions/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using System.Globalization;
 using TC.CloudGames.SharedKernel.Infrastructure.Telemetry;
 using Wolverine.ErrorHandling;
 
@@ -52,7 +53,7 @@ namespace TC.CloudGames.Users.Api.Extensions
                 
                 if (!string.IsNullOrWhiteSpace(samplingRatioConfig))
                 {
-                    if (float.TryParse(samplingRatioConfig, out var ratio))
+                    if (float.TryParse(samplingRatioConfig, System.Globalization.NumberStyles.Float, CultureInfo.InvariantCulture, out var ratio))
                     {
                         if (ratio >= 0.0f && ratio <= 1.0f)
                         {

--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/Extensions/TelemetryExporterInfo.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/Extensions/TelemetryExporterInfo.cs
@@ -1,0 +1,29 @@
+namespace TC.CloudGames.Users.Api.Extensions
+{
+    /// <summary>
+    /// Captures telemetry exporter configuration information for logging.
+    /// Used to defer logging until ILogger is available in Program.cs.
+    /// </summary>
+    internal class TelemetryExporterInfo
+    {
+        /// <summary>
+        /// Type of exporter: "AzureMonitor", "OTLP", or "None"
+        /// </summary>
+        public string ExporterType { get; set; } = "None";
+
+        /// <summary>
+        /// Sampling ratio for Azure Monitor (0.0 to 1.0)
+        /// </summary>
+        public float? SamplingRatio { get; set; }
+
+        /// <summary>
+        /// Endpoint URL for OTLP exporter
+        /// </summary>
+        public string? Endpoint { get; set; }
+
+        /// <summary>
+        /// Protocol for OTLP exporter (grpc or http/protobuf)
+        /// </summary>
+        public string? Protocol { get; set; }
+    }
+}

--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/Program.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/Program.cs
@@ -22,6 +22,11 @@ if (!builder.Environment.IsEnvironment("Testing"))
 var logger = app.Services.GetRequiredService<ILogger<TC.CloudGames.Users.Api.Program>>();
 TelemetryConstants.LogTelemetryConfiguration(logger, app.Configuration);
 
+// Log APM/exporter configuration (Azure Monitor, OTLP, etc.)
+// This info was populated during service configuration in ServiceCollectionExtensions
+var exporterInfo = app.Services.GetService<TC.CloudGames.Users.Api.Extensions.TelemetryExporterInfo>();
+TelemetryConstants.LogApmExporterConfiguration(logger, exporterInfo);
+
 // Use metrics authentication middleware extension
 app.UseIngressPathBase(app.Configuration);
 app.UseMetricsAuthentication();

--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/Telemetry/TelemetryConstants.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/Telemetry/TelemetryConstants.cs
@@ -58,10 +58,10 @@ internal static class TelemetryConstants
 
         // Load Grafana configuration via Helper
         var grafanaSettings = TC.CloudGames.SharedKernel.Infrastructure.Telemetry.GrafanaHelper.Build(configuration);
-        
+
         logger.LogInformation("============================");
         logger.LogInformation("=== GRAFANA AGENT CONFIG ===");
-        
+
         // Agent Status (CRITICAL INFO)
         if (grafanaSettings.Agent.Enabled)
         {
@@ -80,14 +80,14 @@ internal static class TelemetryConstants
             logger.LogWarning("   ? Metrics: /metrics endpoint available (not scraped)");
             logger.LogWarning("   ? To enable: Set Grafana:Agent:Enabled=true or GRAFANA_AGENT_ENABLED=true");
         }
-        
+
         logger.LogInformation("Agent Host: {AgentHost}", grafanaSettings.Agent.Host);
         logger.LogInformation("Agent OTLP gRPC Port: {OtlpGrpcPort}", grafanaSettings.Agent.OtlpGrpcPort);
         logger.LogInformation("Agent OTLP HTTP Port: {OtlpHttpPort}", grafanaSettings.Agent.OtlpHttpPort);
         logger.LogInformation("Agent Metrics Port: {MetricsPort}", grafanaSettings.Agent.MetricsPort);
         logger.LogInformation("OTLP Endpoint: {OtlpEndpoint}", grafanaSettings.Otlp.Endpoint);
         logger.LogInformation("OTLP Protocol: {OtlpProtocol}", grafanaSettings.Otlp.Protocol);
-        logger.LogInformation("OTLP Headers: {OtlpHeaders}", 
+        logger.LogInformation("OTLP Headers: {OtlpHeaders}",
             string.IsNullOrWhiteSpace(grafanaSettings.Otlp.Headers) ? "NOT SET" : "***CONFIGURED***");
         logger.LogInformation("OTLP Timeout: {OtlpTimeout}s", grafanaSettings.Otlp.TimeoutSeconds);
         logger.LogInformation("OTLP Insecure: {OtlpInsecure}", grafanaSettings.Otlp.Insecure);
@@ -106,7 +106,7 @@ internal static class TelemetryConstants
             return;
         }
 
-        logger.LogInformation("???????????????????????????????????????????????????????????????");
+        logger.LogInformation("====================================================================================");
 
         switch (exporterInfo.ExporterType.ToUpperInvariant())
         {
@@ -137,6 +137,6 @@ internal static class TelemetryConstants
                 break;
         }
 
-        logger.LogInformation("???????????????????????????????????????????????????????????????");
+        logger.LogInformation("====================================================================================");
     }
 }

--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/Telemetry/TelemetryConstants.cs
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/Telemetry/TelemetryConstants.cs
@@ -93,4 +93,50 @@ internal static class TelemetryConstants
         logger.LogInformation("OTLP Insecure: {OtlpInsecure}", grafanaSettings.Otlp.Insecure);
         logger.LogInformation("============================");
     }
+
+    /// <summary>
+    /// Logs APM/Telemetry exporter configuration details.
+    /// This should be called from Program.cs after the logger is fully configured.
+    /// </summary>
+    public static void LogApmExporterConfiguration(Microsoft.Extensions.Logging.ILogger logger, TC.CloudGames.Users.Api.Extensions.TelemetryExporterInfo? exporterInfo)
+    {
+        if (exporterInfo == null)
+        {
+            logger.LogWarning("Telemetry exporter information not available");
+            return;
+        }
+
+        logger.LogInformation("???????????????????????????????????????????????????????????????");
+
+        switch (exporterInfo.ExporterType.ToUpperInvariant())
+        {
+            case "AZUREMONITOR":
+                logger.LogInformation("Azure Monitor configured - Telemetry will be exported to Application Insights");
+                logger.LogInformation("Using DefaultAzureCredential for RBAC/Workload Identity authentication");
+                if (exporterInfo.SamplingRatio.HasValue)
+                {
+                    logger.LogInformation("Sampling Ratio: {SamplingRatio:P0}", exporterInfo.SamplingRatio.Value);
+                }
+                logger.LogInformation("Live Metrics: Enabled");
+                break;
+
+            case "OTLP":
+                logger.LogInformation("OTLP Exporter configured - Endpoint: {Endpoint}, Protocol: {Protocol}",
+                    exporterInfo.Endpoint ?? "NOT SET",
+                    exporterInfo.Protocol ?? "NOT SET");
+                break;
+
+            case "NONE":
+                logger.LogWarning("No APM exporter configured - Telemetry will be generated but NOT exported.");
+                logger.LogWarning("To enable Azure Monitor: Set APPLICATIONINSIGHTS_CONNECTION_STRING");
+                logger.LogWarning("To enable Grafana: Set GRAFANA_AGENT_ENABLED=true and OTEL_EXPORTER_OTLP_ENDPOINT");
+                break;
+
+            default:
+                logger.LogWarning("Unknown telemetry exporter type: {ExporterType}", exporterInfo.ExporterType);
+                break;
+        }
+
+        logger.LogInformation("???????????????????????????????????????????????????????????????");
+    }
 }


### PR DESCRIPTION
This pull request improves the configuration and validation of the Azure Monitor sampling ratio in the OpenTelemetry exporter setup. The main focus is on ensuring that the sampling ratio is correctly parsed and falls within the valid range, with clear warnings if misconfigured.

Configuration validation improvements:

* Added validation logic for the `AzureMonitor:SamplingRatio` configuration value to ensure it is a float between 0.0 and 1.0, with fallback to the default value and console warnings for invalid input. (`ServiceCollectionExtensions.cs`, [src/Adapters/Inbound/TC.CloudGames.Users.Api/Extensions/ServiceCollectionExtensions.csL49-R70](diffhunk://#diff-e33cbad8359ceac5c97f95b0fec1b339cb01c7ad4727e014090ecc646fea0924L49-R70))
* Updated usage of the sampling ratio in the Azure Monitor exporter setup to reference the validated value. (`ServiceCollectionExtensions.cs`, [src/Adapters/Inbound/TC.CloudGames.Users.Api/Extensions/ServiceCollectionExtensions.csL65-R83](diffhunk://#diff-e33cbad8359ceac5c97f95b0fec1b339cb01c7ad4727e014090ecc646fea0924L65-R83))Enhanced parsing and validation of AzureMonitor:SamplingRatio config value. Now checks for presence, parses as float, ensures value is between 0.0 and 1.0, and logs warnings for invalid or unparsable values. Defaults to 1.0 if misconfigured, improving reliability and diagnostics.