### PR TITLE
Add libgssapi-krb5-2 to Dockerfile for Kerberos support

### DIFF
--- a/src/Adapters/Inbound/TC.CloudGames.Users.Api/Dockerfile
+++ b/src/Adapters/Inbound/TC.CloudGames.Users.Api/Dockerfile
@@ -2,6 +2,8 @@
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+USER root
+RUN apt-get update && apt-get install -y libgssapi-krb5-2 && rm -rf /var/lib/apt/lists/*
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080


### PR DESCRIPTION
Switched to root user in Dockerfile to install libgssapi-krb5-2, enabling Kerberos authentication capabilities. Cleaned up apt cache after installation to reduce image size.