### PR TITLE
Return NotAuthorized for invalid login credentials

### DIFF
--- a/src/Core/TC.CloudGames.Users.Application/UseCases/LoginUser/LoginUserCommandHandler.cs
+++ b/src/Core/TC.CloudGames.Users.Application/UseCases/LoginUser/LoginUserCommandHandler.cs
@@ -30,8 +30,8 @@ internal sealed class LoginUserCommandHandler : BaseHandler<LoginUserCommand, Lo
                      UserDomainErrors.InvalidCredentials.ErrorMessage,
                      UserDomainErrors.InvalidCredentials.ErrorCode);
 
-            // Returns a NotFound result using the shared validation helper
-            return BuildNotFoundResult();
+            // Returns a NotAuthorized result using the shared validation helper
+            return BuildNotAuthorizedResult();
         }
 
         var response = new LoginUserResponse(


### PR DESCRIPTION
Changed login handler to return NotAuthorized instead of NotFound when user credentials are invalid, ensuring more accurate authentication error responses.